### PR TITLE
Add ability to control Fastly Caching behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Module Input Variables
 - `component` - (string) - **REQUIRED** - component name
 - `platform_config` - (map) **REQUIRED** - Mergermarket Platform config dictionary (see tests for example one)
 - `backend_ip` - (string) - If set to IP - it'll cause a proxying service to be deployed that will proxy - by default - all requests to given IP; this IP should be / can be different per environment and configured via `config` mechanism.  Default `404` - will deploy service that - by default - returns 404s to all requests
+- `fastly_caching` - (bool) - Controls whether to enable / forcefully disable caching (default: true)
 
 Usage
 -----
@@ -52,7 +53,8 @@ module "frontend_router" {
   platform_config = "${var.platform_config}"
 
   # optional
-  # backend_ip = "1.1.1.1"
+  # backend_ip     = "1.1.1.1"
+  # fastly_caching = "false"
 }
 ```
 

--- a/fastly.tf
+++ b/fastly.tf
@@ -4,4 +4,5 @@ module "fastly" {
   domain_name     = "${var.dns_domain}"
   backend_address = "${module.alb.alb_dns_name}"
   env             = "${var.env}"
+  caching         = "${var.fastly_caching}"
 }

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -24,6 +24,19 @@ module "frontend_router" {
   # backend_ip = "1.1.1.1"
 }
 
+module "frontend_router_disable_fastly_caching" {
+  source = "../.."
+
+  dns_domain      = "${var.dns_domain}"
+  team            = "${var.team}"
+  env             = "${var.env}"
+  component       = "${var.component}"
+  platform_config = "${var.platform_config}"
+
+  # optional
+  fastly_caching = "false"
+}
+
 # variables
 variable "dns_domain" {}
 

--- a/test/test_tf_frontend_router.py
+++ b/test/test_tf_frontend_router.py
@@ -364,6 +364,47 @@ Plan: 10 to add, 0 to change, 0 to destroy.
     header.3700817666.response_condition:         ""
         """.strip() in output # noqa
 
+    def test_create_fastly_config_disable_fastly_caching(self):
+        # When
+        output = check_output([
+            'terraform',
+            'plan',
+            '-var', 'env=foo',
+            '-var', 'component=foobar',
+            '-var', 'team=foobar',
+            '-var', 'aws_region=eu-west-1',
+            '-var', 'dns_domain=domain.com',
+            '-var-file={}/test/platform-config/eu-west-1.json'.format(
+                self.base_path
+            ),
+            '-no-color'
+        ] + self._target_module('frontend_router_disable_fastly_caching') + [
+            self.module_path
+        ], env=self._env_for_check_output('qwerty'), cwd=self.workdir).decode(
+            'utf-8'
+        )
+
+        # Then
+        assert """
++ module.frontend_router_disable_fastly_caching.fastly.fastly_service_v1.fastly
+        """.strip() in output # noqa
+
+        assert """
+    request_setting.#:                            "1"
+    request_setting.2432135539.action:            ""
+    request_setting.2432135539.bypass_busy_wait:  ""
+    request_setting.2432135539.default_host:      ""
+    request_setting.2432135539.force_miss:        "true"
+    request_setting.2432135539.force_ssl:         "true"
+    request_setting.2432135539.geo_headers:       ""
+    request_setting.2432135539.hash_keys:         ""
+    request_setting.2432135539.max_stale_age:     "60"
+    request_setting.2432135539.name:              "disable caching"
+    request_setting.2432135539.request_condition: "all_urls"
+    request_setting.2432135539.timer_support:     ""
+    request_setting.2432135539.xff:               "append"
+        """.strip() in output # noqa
+
     @given(
         env=sampled_from(('ci', 'dev', 'aslive', 'live')),
         component=text(alphabet=ascii_lowercase, min_size=16, max_size=32)

--- a/variables.tf
+++ b/variables.tf
@@ -33,3 +33,9 @@ variable "backend_ip" {
   type        = "string"
   default     = "404"
 }
+
+variable "fastly_caching" {
+  description = "Whether to enable / forcefully disable caching on Fastly (default: true)"
+  type        = "string"
+  default     = "true"
+}


### PR DESCRIPTION
We want to be able to control Fastly caching behaviour; by default
Fastly caching is enabled, but you can now override it and disable it if
this is desired.