### PR TITLE
Fix bug where subnets were passed as a string

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ module "alb" {
 
   name                     = "${join("", slice(split("", format("%s-%s", var.env, var.component)), 0, length(format("%s-%s", var.env, var.component)) > 22 ? 23 : length(format("%s-%s", var.env, var.component))))}-router"
   vpc_id                   = "${var.platform_config["vpc"]}"
-  subnet_ids               = ["${var.platform_config["public_subnets"]}"]
+  subnet_ids               = ["${split(",", var.platform_config["public_subnets"])}"]
   internal                 = "false"
   certificate_arn          = "${var.platform_config["elb_certificates.${replace(var.alb_domain, "/\\./", "_")}"]}"
   default_target_group_arn = "${module.default_backend_ecs_service.target_group_arn}"

--- a/test/test_tf_frontend_router.py
+++ b/test/test_tf_frontend_router.py
@@ -187,8 +187,10 @@ Plan: 10 to add, 0 to change, 0 to destroy.
     ip_address_type:            "<computed>"
     name:                       "foo-foobar-router"
     security_groups.#:          "<computed>"
-    subnets.#:                  "1"
-    subnets.939944885:          "subnet-33333333,subnet-44444444,subnet-55555555"
+    subnets.#:                  "3"
+    subnets.3082459916:         "subnet-55555555"
+    subnets.3586363601:         "subnet-33333333"
+    subnets.4231620278:         "subnet-44444444"
     vpc_id:                     "<computed>"
     zone_id:                    "<computed>"
         """.strip() in output # noqa


### PR DESCRIPTION
Subnets for ALB to use were being passed as a string, resulting in it being:

1) Wrong - as it's a string of 3 subnets divided wih `,` 
2) There was just one element, where at least 2 are required

This commit fixes this bug by splitting the string on the way into the `tf_alb module`

### How to test

Run tests; I've updated them, too