### PR TITLE
Make the ECS service depend on the ALB

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,12 +32,14 @@ module "default_backend_task_definition" {
 module "default_backend_ecs_service" {
   source = "github.com/mergermarket/tf_load_balanced_ecs_service"
 
-  name            = "${join("", slice(split("", format("%s-%s", var.env, var.component)), 0, length(format("%s-%s", var.env, var.component)) > 22 ? 23 : length(format("%s-%s", var.env, var.component))))}-default"
-  container_name  = "${var.backend_ip == "404" ? "404" : "haproxy"}"
-  container_port  = "80"
-  vpc_id          = "${var.platform_config["vpc"]}"
-  task_definition = "${module.default_backend_task_definition.arn}"
-  desired_count   = "${var.env == "live" ? 2 : 1}"
+  name             = "${join("", slice(split("", format("%s-%s", var.env, var.component)), 0, length(format("%s-%s", var.env, var.component)) > 22 ? 23 : length(format("%s-%s", var.env, var.component))))}-default"
+  container_name   = "${var.backend_ip == "404" ? "404" : "haproxy"}"
+  container_port   = "80"
+  vpc_id           = "${var.platform_config["vpc"]}"
+  task_definition  = "${module.default_backend_task_definition.arn}"
+  desired_count    = "${var.env == "live" ? 2 : 1}"
+  alb_listener_arn = "${module.alb.alb_listener_arn}"
+  alb_arn          = "${module.alb.alb_arn}"
 }
 
 module "alb" {

--- a/test/test_tf_frontend_router.py
+++ b/test/test_tf_frontend_router.py
@@ -51,7 +51,6 @@ class TestTFFrontendRouter(unittest.TestCase):
         self.module_path = os.path.join(os.getcwd(), 'test', 'infra')
 
         check_call(['terraform', 'init', self.module_path], cwd=self.workdir)
-        check_call(['terraform', 'get', self.module_path], cwd=self.workdir)
 
     def tearDown(self):
         if os.path.isdir(self.workdir):


### PR DESCRIPTION
Without this dependency the service creation often fails complaining that the load balancer isn't present for it to plug into.

JIRA: PLAT-1022