### PR TITLE
Use Logentries LogSet data source

### DIFF
--- a/fastly.tf
+++ b/fastly.tf
@@ -4,7 +4,6 @@ module "fastly" {
   domain_name           = "${var.fastly_domain}"
   backend_address       = "${module.alb.alb_dns_name}"
   env                   = "${var.env}"
-  le_logset_id          = "${var.le_logset_id}"
   caching               = "${var.fastly_caching}"
   ssl_cert_check        = "${var.ssl_cert_check}"
   ssl_cert_hostname     = "${var.ssl_cert_hostname}"

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -8,7 +8,7 @@ ENV TERRAFORM_PROVIDER_FASTLY_VERSION=0.1.2_le-support
 ENV TERRAFORM_PROVIDER_NULL_VERSION=0.1.0
 ENV TERRAFORM_PROVIDER_TEMPLATE_VERSION=0.1.1
 ENV TERRAFORM_PROVIDER_ACME_VERSION=0.3.0
-ENV TERRAFORM_PROVIDER_LOGENTRIES_VERSION=0.1.0
+ENV TERRAFORM_PROVIDER_LOGENTRIES_VERSION=0.1.0_logset_datasource
 
 ENV PYTHONDONTWRITEBYTECODE donot
 
@@ -25,8 +25,8 @@ RUN apk update && apk add ca-certificates curl git openssl wget && \
         unzip terraform-provider-null_*_linux_amd64.zip -d /usr/bin && \
     wget -q https://releases.hashicorp.com/terraform-provider-template/${TERRAFORM_PROVIDER_TEMPLATE_VERSION}/terraform-provider-template_${TERRAFORM_PROVIDER_TEMPLATE_VERSION}_linux_amd64.zip && \
         unzip terraform-provider-template_*_linux_amd64.zip -d /usr/bin && \
-    wget -q https://releases.hashicorp.com/terraform-provider-logentries/${TERRAFORM_PROVIDER_LOGENTRIES_VERSION}/terraform-provider-logentries_${TERRAFORM_PROVIDER_LOGENTRIES_VERSION}_linux_amd64.zip && \
-            unzip terraform-provider-logentries_*_linux_amd64.zip -d /usr/bin && \
+    wget -q https://s3-eu-west-1.amazonaws.com/mmg-terraform-providers/terraform-provider-logentries_v${TERRAFORM_PROVIDER_LOGENTRIES_VERSION}_linux_amd64.zip && \
+        unzip terraform-provider-logentries_*_linux_amd64.zip -d /usr/bin && \
     wget -q https://github.com/paybyphone/terraform-provider-acme/releases/download/v${TERRAFORM_PROVIDER_ACME_VERSION}/terraform-provider-acme_v${TERRAFORM_PROVIDER_ACME_VERSION}_linux_amd64.zip && \
         unzip terraform-provider-acme_*_linux_amd64.zip -d /usr/bin && \
     rm -rf /tmp/* /var/cache/apk/* /var/tmp/*

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -20,7 +20,6 @@ module "frontend_router" {
   env             = "${var.env}"
   component       = "${var.component}"
   platform_config = "${var.platform_config}"
-  le_logset_id    = "${var.le_logset_id}"
 
   # optional
   # backend_ip = "1.1.1.1"
@@ -35,7 +34,6 @@ module "frontend_router_disable_fastly_caching" {
   env             = "${var.env}"
   component       = "${var.component}"
   platform_config = "${var.platform_config}"
-  le_logset_id    = "${var.le_logset_id}"
 
   # optional
   fastly_caching = "false"
@@ -53,7 +51,6 @@ module "frontend_router_timeouts" {
   connect_timeout       = "${var.connect_timeout}"
   first_byte_timeout    = "${var.first_byte_timeout}"
   between_bytes_timeout = "${var.between_bytes_timeout}"
-  le_logset_id          = "${var.le_logset_id}"
 }
 
 # variables
@@ -66,10 +63,6 @@ variable "team" {}
 variable "env" {}
 
 variable "component" {}
-
-variable "le_logset_id" {
-  default = "123"
-}
 
 variable "backend_ip" {
   default = "404"

--- a/test/test_tf_frontend_router.py
+++ b/test/test_tf_frontend_router.py
@@ -869,7 +869,9 @@ Plan: 13 to add, 0 to change, 0 to destroy.
 
         assert """
   + module.frontend_router.module.fastly.logentries_log.logs
-      logset_id:        "123"
+        """.strip() in output # noqa
+
+        assert """
       name:             "dev-externaldomain.com"
       retention_period: "ACCOUNT_DEFAULT"
       source:           "token"

--- a/variables.tf
+++ b/variables.tf
@@ -27,11 +27,6 @@ variable "platform_config" {
   default     = {}
 }
 
-variable "le_logset_id" {
-  description = "Logentries Logset ID"
-  type        = "string"
-}
-
 # optional
 variable "alb_domain" {
   description = ""


### PR DESCRIPTION
We'd like to be able to use Logentries LogSet data source to pass parent LogSet ID where Logs will be created, instead of passing the ID into the module.

This way we can remove an entry from platform-config making it less complex and thinner.