### PR TITLE
Add ability to override healthcheck configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Module Input Variables
 - `fastly_caching` - (bool) - Controls whether to enable / forcefully disable caching (default: true)
 - `ssl_cert_check` - (bool) - Check the backend cert is valid - warning disabling this makes you vulnerable to a man-in-the-middle imporsonating your backend (default `true`)
 - `ssl_cert_hostname` - (bool) - The hostname to validate the certificate presented by the backend against (default `""`)
+- `health_check_interval` - (string) - (default "5") The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds.
+- `health_check_path` - (string) - The destination for the health check request (default `"/internal/healthcheck"`)
+- `health_check_timeout` - (string) - The amount of time, in seconds, during which no response means a failed health check (default `"4"`)
+- `health_check_healthy_threshold` - (string) - The number of consecutive health checks successes required before considering an unhealthy target healthy (default `"2"`)
+- `health_check_unhealthy_threshold` - (string) - The number of consecutive health check failures required before considering the target unhealthy (default `"2"`)
+- `health_check_matcher` - (string) - The HTTP codes to use when checking for a successful response from a target. You can specify multiple values (for example, "200,202") or a range of values (for example, "200-299") (default `"200-299"`) 
 
 Usage
 -----

--- a/main.tf
+++ b/main.tf
@@ -32,14 +32,20 @@ module "default_backend_task_definition" {
 module "default_backend_ecs_service" {
   source = "github.com/mergermarket/tf_load_balanced_ecs_service"
 
-  name             = "${join("", slice(split("", format("%s-%s", var.env, var.component)), 0, length(format("%s-%s", var.env, var.component)) > 22 ? 23 : length(format("%s-%s", var.env, var.component))))}-default"
-  container_name   = "${var.backend_ip == "404" ? "404" : "haproxy"}"
-  container_port   = "80"
-  vpc_id           = "${var.platform_config["vpc"]}"
-  task_definition  = "${module.default_backend_task_definition.arn}"
-  desired_count    = "${var.env == "live" ? 2 : 1}"
-  alb_listener_arn = "${module.alb.alb_listener_arn}"
-  alb_arn          = "${module.alb.alb_arn}"
+  name                             = "${join("", slice(split("", format("%s-%s", var.env, var.component)), 0, length(format("%s-%s", var.env, var.component)) > 22 ? 23 : length(format("%s-%s", var.env, var.component))))}-default"
+  container_name                   = "${var.backend_ip == "404" ? "404" : "haproxy"}"
+  container_port                   = "80"
+  vpc_id                           = "${var.platform_config["vpc"]}"
+  task_definition                  = "${module.default_backend_task_definition.arn}"
+  desired_count                    = "${var.env == "live" ? 2 : 1}"
+  alb_listener_arn                 = "${module.alb.alb_listener_arn}"
+  alb_arn                          = "${module.alb.alb_arn}"
+  health_check_path                = "${var.health_check_path}"
+  health_check_interval            = "${var.health_check_interval}"
+  health_check_timeout             = "${var.health_check_timeout}"
+  health_check_healthy_threshold   = "${var.health_check_healthy_threshold}"
+  health_check_unhealthy_threshold = "${var.health_check_unhealthy_threshold}"
+  health_check_matcher             = "${var.health_check_matcher}"
 }
 
 module "alb" {

--- a/variables.tf
+++ b/variables.tf
@@ -75,3 +75,39 @@ variable "between_bytes_timeout" {
   description = ""
   default     = 30000
 }
+
+variable "health_check_interval" {
+  description = "The approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds."
+  type        = "string"
+  default     = "5"
+}
+
+variable "health_check_path" {
+  description = "The destination for the health check request."
+  type        = "string"
+  default     = "/internal/healthcheck"
+}
+
+variable "health_check_timeout" {
+  description = "The amount of time, in seconds, during which no response means a failed health check."
+  type        = "string"
+  default     = "4"
+}
+
+variable "health_check_healthy_threshold" {
+  description = "The number of consecutive health checks successes required before considering an unhealthy target healthy."
+  type        = "string"
+  default     = "2"
+}
+
+variable "health_check_unhealthy_threshold" {
+  description = "The number of consecutive health check failures required before considering the target unhealthy."
+  type        = "string"
+  default     = "2"
+}
+
+variable "health_check_matcher" {
+  description = "The HTTP codes to use when checking for a successful response from a target. You can specify multiple values (for example, \"200,202\") or a range of values (for example, \"200-299\")."
+  type        = "string"
+  default     = "200-299"
+}


### PR DESCRIPTION
 We'd like to be able to override healthcheck configuration; this is useful eg. in scenario where we use BACKEND_IP and the actual backend has got non-standard healthcheck endpoint.