### PR TITLE
Don't leave multiple neighbouring dashes in names

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,14 +25,14 @@ module "haproxy_proxy_container_definition" {
 module "default_backend_task_definition" {
   source = "github.com/mergermarket/tf_ecs_task_definition"
 
-  family                = "${join("", slice(split("", format("%s-%s", var.env, var.component)), 0, length(format("%s-%s", var.env, var.component)) > 22 ? 23 : length(format("%s-%s", var.env, var.component))))}-default"
+  family                = "${format("%s-%s", var.env, var.component)}-default"
   container_definitions = ["${var.backend_ip == "404" ? module.404_container_definition.rendered : module.haproxy_proxy_container_definition.rendered}"]
 }
 
 module "default_backend_ecs_service" {
   source = "github.com/mergermarket/tf_load_balanced_ecs_service"
 
-  name                             = "${join("", slice(split("", format("%s-%s", var.env, var.component)), 0, length(format("%s-%s", var.env, var.component)) > 22 ? 23 : length(format("%s-%s", var.env, var.component))))}-default"
+  name                             = "${replace(replace(format("%s-%s", var.env, var.component), "/(.{0,24}).*/", "$1"), "/^-+|-+$/", "")}-default"
   container_name                   = "${var.backend_ip == "404" ? "404" : "haproxy"}"
   container_port                   = "${var.backend_ip == "404" ? "80" : "8000"}"
   vpc_id                           = "${var.platform_config["vpc"]}"
@@ -51,7 +51,7 @@ module "default_backend_ecs_service" {
 module "alb" {
   source = "github.com/mergermarket/tf_alb.git"
 
-  name                     = "${join("", slice(split("", format("%s-%s", var.env, var.component)), 0, length(format("%s-%s", var.env, var.component)) > 22 ? 23 : length(format("%s-%s", var.env, var.component))))}-router"
+  name                     = "${replace(replace(format("%s-%s", var.env, var.component), "/(.{0,25}).*/", "$1"), "/^-+|-+$/", "")}-router"
   vpc_id                   = "${var.platform_config["vpc"]}"
   subnet_ids               = ["${split(",", var.platform_config["public_subnets"])}"]
   extra_security_groups    = ["${var.platform_config["ecs_cluster.default.client_security_group"]}"]


### PR DESCRIPTION
We need to truncate some names before they can be used in AWS but we need to avoid leaving trailing `-` characters before appending e.g. `-default` as the double `-` is illegal in AWS.

This uses regexes to truncate the string and then remove all preceding and trailing slashes.