### PR TITLE
Added an alias for the alb

### DIFF
--- a/fastly.tf
+++ b/fastly.tf
@@ -1,5 +1,5 @@
 module "fastly" {
-    source = "git::https://github.com/mergermarket/tf_fastly_frontend.git"
+  source = "github.com/mergermarket/tf_fastly_frontend"
 
   domain_name               = "${var.fastly_domain}"
   bare_redirect_domain_name = "${var.bare_redirect_domain_name}"
@@ -7,7 +7,7 @@ module "fastly" {
   env                       = "${var.env}"
   caching                   = "${var.fastly_caching}"
   ssl_cert_check            = "${var.ssl_cert_check}"
-  ssl_cert_hostname         = "${format("%s-%s%s.%s", var.env, var.component, var.env != "live" ? ".dev" : "", var.alb_domain)}"
+  ssl_cert_hostname         = "${aws_route53_record.alb_alias.fqdn}"
   connect_timeout           = "${var.connect_timeout}"
   first_byte_timeout        = "${var.first_byte_timeout}"
   between_bytes_timeout     = "${var.between_bytes_timeout}"

--- a/fastly.tf
+++ b/fastly.tf
@@ -7,7 +7,7 @@ module "fastly" {
   env                       = "${var.env}"
   caching                   = "${var.fastly_caching}"
   ssl_cert_check            = "${var.ssl_cert_check}"
-  ssl_cert_hostname         = "${aws_route53_record.alb_alias.fqdn}"
+  ssl_cert_hostname         = "${module.dns_record.fqdn}"
   connect_timeout           = "${var.connect_timeout}"
   first_byte_timeout        = "${var.first_byte_timeout}"
   between_bytes_timeout     = "${var.between_bytes_timeout}"

--- a/fastly.tf
+++ b/fastly.tf
@@ -1,5 +1,5 @@
 module "fastly" {
-  source = "git::https://github.com/mergermarket/tf_fastly_frontend.git"
+    source = "git::https://github.com/mergermarket/tf_fastly_frontend.git"
 
   domain_name               = "${var.fastly_domain}"
   bare_redirect_domain_name = "${var.bare_redirect_domain_name}"
@@ -7,7 +7,7 @@ module "fastly" {
   env                       = "${var.env}"
   caching                   = "${var.fastly_caching}"
   ssl_cert_check            = "${var.ssl_cert_check}"
-  ssl_cert_hostname         = "${var.ssl_cert_hostname}"
+  ssl_cert_hostname         = "${format("%s-%s%s.%s", var.env, var.component, var.env != "live" ? ".dev" : "", var.alb_domain)}"
   connect_timeout           = "${var.connect_timeout}"
   first_byte_timeout        = "${var.first_byte_timeout}"
   between_bytes_timeout     = "${var.between_bytes_timeout}"

--- a/main.tf
+++ b/main.tf
@@ -68,3 +68,15 @@ module "alb" {
     team        = "${var.team}"
   }
 }
+
+resource "aws_route53_record" "alb_alias" {
+  zone_id = "${module.alb.alb_zone_id}"
+  name    = "${format("%s-%s%s.%s", var.env, var.component, var.env == "live" ? "" : ".dev", var.alb_domain)}"
+  type    = "A"
+
+  alias {
+    name                   = "${module.alb.alb_dns_name}"
+    zone_id                = "${module.alb.alb_zone_id}"
+    evaluate_target_health = true
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -70,7 +70,7 @@ module "alb" {
 }
 
 module "dns_record" {
-  source = "github.com/mergermarket/tf_route53_dns?ref=PLAT-1117_frontend-boilerplate-dns"
+  source = "github.com/mergermarket/tf_route53_dns"
 
   domain      = "${var.alb_domain}"
   name        = "${var.component}"

--- a/main.tf
+++ b/main.tf
@@ -69,26 +69,12 @@ module "alb" {
   }
 }
 
-data "aws_route53_zone" "dns_domain" {
-  name  = "${data.template_file.domain.rendered}"
-}
+module "dns_record" {
+  source = "github.com/mergermarket/tf_route53_dns?ref=PLAT-1117_frontend-boilerplate-dns"
 
-data "template_file" "domain" {
-  template = "$${env == "live" ? "$${domain}" : "dev.$${domain}"}."
-  vars {
-    env    = "${var.env}"
-    domain = "${var.alb_domain}"
-  }
-}
-
-resource "aws_route53_record" "alb_alias" {
-  zone_id = "${data.aws_route53_zone.dns_domain.zone_id}"
-  name    = "${var.env == "live" ? "${var.component}" : "${var.env}-${var.component}"}.${data.template_file.domain.rendered}"
-  type    = "A"
-
-  alias {
-    name                   = "${module.alb.alb_dns_name}"
-    zone_id                = "${module.alb.alb_zone_id}"
-    evaluate_target_health = true
-  }
+  domain      = "${var.alb_domain}"
+  name        = "${var.component}"
+  env         = "${var.env}"
+  target      = "${module.alb.alb_dns_name}"
+  alb_zone_id = "${module.alb.alb_zone_id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -77,4 +77,5 @@ module "dns_record" {
   env         = "${var.env}"
   target      = "${module.alb.alb_dns_name}"
   alb_zone_id = "${module.alb.alb_zone_id}"
+  alias       = "1"
 }

--- a/test/test_tf_frontend_router.py
+++ b/test/test_tf_frontend_router.py
@@ -43,16 +43,20 @@ def template_to_re(t):
 
 class TestTFFrontendRouter(unittest.TestCase):
 
-    def setUp(self):
-        self.workdir = tempfile.mkdtemp()
-        self.base_path = os.getcwd()
-        self.module_path = os.path.join(os.getcwd(), 'test', 'infra')
+    @classmethod
+    def setup_class(cls):
+        cls.workdir = tempfile.mkdtemp()
+        cls.base_path = os.getcwd()
+        cls.module_path = os.path.join(os.getcwd(), 'test', 'infra')
 
-        check_call(['terraform', 'init', self.module_path], cwd=self.workdir)
+        check_call(['terraform', 'init', cls.module_path], cwd=cls.workdir)
 
-    def tearDown(self):
-        if os.path.isdir(self.workdir):
-            shutil.rmtree(self.workdir)
+    @classmethod
+    def teardown_class(cls):
+        try:
+            shutil.rmtree(cls.workdir)
+        except Exception as e:
+            print('Error removing {}: {}', cls.workdir, e)
 
     def _env_for_check_output(self, fastly_api_key):
         env = os.environ.copy()
@@ -102,7 +106,7 @@ class TestTFFrontendRouter(unittest.TestCase):
 
         # Then
         assert """
-Plan: 14 to add, 0 to change, 0 to destroy.
+Plan: 15 to add, 0 to change, 0 to destroy.
         """.strip() in output
 
     @given(fixed_dictionaries({
@@ -409,20 +413,27 @@ Plan: 14 to add, 0 to change, 0 to destroy.
         ), cwd=self.workdir).decode('utf-8')
 
         # Then
-        assert re.search(template_to_re("""
-      backend.~{ident}.healthcheck:               ""
-      backend.~{ident}.max_conn:                  "200"
-      backend.~{ident}.name:                      "default backend"
-      backend.~{ident}.port:                      "443"
-      backend.~{ident}.request_condition:         ""
-      backend.~{ident}.shield:                    ""
-      backend.~{ident}.ssl_ca_cert:               ""
-      backend.~{ident}.ssl_cert_hostname:         "foo-foobar.dev.domain.com"
-      backend.~{ident}.ssl_check_cert:            "true"
-      backend.~{ident}.ssl_hostname:              ""
-      backend.~{ident}.ssl_sni_hostname:          ""
-      backend.~{ident}.weight:                    "100"
-        """.strip()), output) # noqa
+        assert """
+      backend.#:                                    "1"
+      backend.~3792877954.address:                  "${var.backend_address}"
+      backend.~3792877954.auto_loadbalance:         "true"
+      backend.~3792877954.between_bytes_timeout:    "30000"
+      backend.~3792877954.connect_timeout:          "5000"
+      backend.~3792877954.error_threshold:          "0"
+      backend.~3792877954.first_byte_timeout:       "60000"
+      backend.~3792877954.healthcheck:              ""
+      backend.~3792877954.max_conn:                 "200"
+      backend.~3792877954.name:                     "default backend"
+      backend.~3792877954.port:                     "443"
+      backend.~3792877954.request_condition:        ""
+      backend.~3792877954.shield:                   ""
+      backend.~3792877954.ssl_ca_cert:              ""
+      backend.~3792877954.ssl_cert_hostname:        "${var.ssl_cert_hostname}"
+      backend.~3792877954.ssl_check_cert:           "true"
+      backend.~3792877954.ssl_hostname:             ""
+      backend.~3792877954.ssl_sni_hostname:         ""
+      backend.~3792877954.weight:                   "100"
+        """.strip() in output
 
     def test_create_fastly_config_all_urls_condition(self):
         # When

--- a/test/test_tf_frontend_router.py
+++ b/test/test_tf_frontend_router.py
@@ -413,27 +413,27 @@ Plan: 15 to add, 0 to change, 0 to destroy.
         ), cwd=self.workdir).decode('utf-8')
 
         # Then
-        assert """
+        assert re.search(template_to_re("""
       backend.#:                                    "1"
-      backend.~3792877954.address:                  "${var.backend_address}"
-      backend.~3792877954.auto_loadbalance:         "true"
-      backend.~3792877954.between_bytes_timeout:    "30000"
-      backend.~3792877954.connect_timeout:          "5000"
-      backend.~3792877954.error_threshold:          "0"
-      backend.~3792877954.first_byte_timeout:       "60000"
-      backend.~3792877954.healthcheck:              ""
-      backend.~3792877954.max_conn:                 "200"
-      backend.~3792877954.name:                     "default backend"
-      backend.~3792877954.port:                     "443"
-      backend.~3792877954.request_condition:        ""
-      backend.~3792877954.shield:                   ""
-      backend.~3792877954.ssl_ca_cert:              ""
-      backend.~3792877954.ssl_cert_hostname:        "${var.ssl_cert_hostname}"
-      backend.~3792877954.ssl_check_cert:           "true"
-      backend.~3792877954.ssl_hostname:             ""
-      backend.~3792877954.ssl_sni_hostname:         ""
-      backend.~3792877954.weight:                   "100"
-        """.strip() in output
+      backend.~{ident}.address:                  "${{var.backend_address}}"
+      backend.~{ident}.auto_loadbalance:         "true"
+      backend.~{ident}.between_bytes_timeout:    "30000"
+      backend.~{ident}.connect_timeout:          "5000"
+      backend.~{ident}.error_threshold:          "0"
+      backend.~{ident}.first_byte_timeout:       "60000"
+      backend.~{ident}.healthcheck:              ""
+      backend.~{ident}.max_conn:                 "200"
+      backend.~{ident}.name:                     "default backend"
+      backend.~{ident}.port:                     "443"
+      backend.~{ident}.request_condition:        ""
+      backend.~{ident}.shield:                   ""
+      backend.~{ident}.ssl_ca_cert:              ""
+      backend.~{ident}.ssl_cert_hostname:        "${{var.ssl_cert_hostname}}"
+      backend.~{ident}.ssl_check_cert:           "true"
+      backend.~{ident}.ssl_hostname:             ""
+      backend.~{ident}.ssl_sni_hostname:         ""
+      backend.~{ident}.weight:                   "100"
+        """.strip()), output)
 
     def test_create_fastly_config_all_urls_condition(self):
         # When

--- a/test/test_tf_frontend_router.py
+++ b/test/test_tf_frontend_router.py
@@ -410,18 +410,18 @@ Plan: 14 to add, 0 to change, 0 to destroy.
 
         # Then
         assert re.search(template_to_re("""
-      backend.~{ident}.healthcheck:              ""
-      backend.~{ident}.max_conn:                 "200"
-      backend.~{ident}.name:                     "default backend"
-      backend.~{ident}.port:                     "443"
-      backend.~{ident}.request_condition:        ""
-      backend.~{ident}.shield:                   ""
-      backend.~{ident}.ssl_ca_cert:              ""
-      backend.~{ident}.ssl_cert_hostname:        ""
-      backend.~{ident}.ssl_check_cert:           "true"
-      backend.~{ident}.ssl_hostname:             ""
-      backend.~{ident}.ssl_sni_hostname:         ""
-      backend.~{ident}.weight:                   "100"
+      backend.~{ident}.healthcheck:               ""
+      backend.~{ident}.max_conn:                  "200"
+      backend.~{ident}.name:                      "default backend"
+      backend.~{ident}.port:                      "443"
+      backend.~{ident}.request_condition:         ""
+      backend.~{ident}.shield:                    ""
+      backend.~{ident}.ssl_ca_cert:               ""
+      backend.~{ident}.ssl_cert_hostname:         "foo-foobar.dev.domain.com"
+      backend.~{ident}.ssl_check_cert:            "true"
+      backend.~{ident}.ssl_hostname:              ""
+      backend.~{ident}.ssl_sni_hostname:          ""
+      backend.~{ident}.weight:                    "100"
         """.strip()), output) # noqa
 
     def test_create_fastly_config_all_urls_condition(self):


### PR DESCRIPTION
Using the alias for the cert hostname in fastly. 

According to Terraform docs:
https://www.terraform.io/docs/providers/aws/r/route53_record.html#alias-record

Don't know what the terraform output looks like, I'd suggest not merging this until a new version of the fastly provider comes out with the logentries integration. So we can see the output.

https://github.com/terraform-providers/terraform-provider-fastly

JIRA: PLAT-1117