### PR TITLE
Add ability to specify backend port

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Module Input Variables
 - `platform_config` - (map) **REQUIRED** - Mergermarket Platform config dictionary (see tests for example one)
 - `alb_domain` - (string) - DNS Domain name to be used as a entry to the service (Fastly will be configured to use it)
 - `backend_ip` - (string) - If set to IP - it'll cause a proxying service to be deployed that will proxy - by default - all requests to given IP; this IP should be / can be different per environment and configured via `config` mechanism.  Default `404` - will deploy service that - by default - returns 404s to all requests
+- `backend_port` - (string) - Port number the requests to the backend will be sent to (default `80`)
 - `fastly_caching` - (bool) - Controls whether to enable / forcefully disable caching (default: true)
 - `ssl_cert_check` - (bool) - Check the backend cert is valid - warning disabling this makes you vulnerable to a man-in-the-middle imporsonating your backend (default `true`)
 - `ssl_cert_hostname` - (bool) - The hostname to validate the certificate presented by the backend against (default `""`)

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,8 @@ module "haproxy_proxy_container_definition" {
   container_port = "8000"
 
   container_env = {
-    BACKEND_IP = "${var.backend_ip}"
+    BACKEND_IP   = "${var.backend_ip}"
+    BACKEND_PORT = "${var.backend_port}"
   }
 }
 

--- a/test/test_tf_frontend_router.py
+++ b/test/test_tf_frontend_router.py
@@ -105,7 +105,7 @@ class TestTFFrontendRouter(unittest.TestCase):
 
         # Then
         assert """
-Plan: 13 to add, 0 to change, 0 to destroy.
+Plan: 14 to add, 0 to change, 0 to destroy.
         """.strip() in output
 
     def test_create_default_404_service_target_group(self):

--- a/variables.tf
+++ b/variables.tf
@@ -40,6 +40,12 @@ variable "backend_ip" {
   default     = "404"
 }
 
+variable "backend_port" {
+  description = "Backend port to use; default: 80"
+  type        = "string"
+  default     = "80"
+}
+
 variable "ssl_cert_check" {
   description = "Check the backend cert is valid"
   type        = "string"


### PR DESCRIPTION
We'd like to be able to specify backend port the proxy will be communicating with (if being used).

Keep it to 80 by default for backwards compatibility reasons.