### PR TITLE
Pass through vcl variables

### DIFF
--- a/fastly.tf
+++ b/fastly.tf
@@ -11,4 +11,6 @@ module "fastly" {
   connect_timeout           = "${var.connect_timeout}"
   first_byte_timeout        = "${var.first_byte_timeout}"
   between_bytes_timeout     = "${var.between_bytes_timeout}"
+  custom_vcl_backends       = "${var.custom_vcl_backends}"
+  custom_vcl_recv           = "${var.custom_vcl_recv}"
 }

--- a/test/test_tf_frontend_router.py
+++ b/test/test_tf_frontend_router.py
@@ -346,22 +346,31 @@ Plan: 15 to add, 0 to change, 0 to destroy.
       egress.{ident1}.security_groups.#:    "0"
       egress.{ident1}.self:                 "false"
       egress.{ident1}.to_port:              "0"
-      ingress.#:                             "1"
+      ingress.#:                             "2"
       ingress.{ident2}.cidr_blocks.#:      "1"
       ingress.{ident2}.cidr_blocks.0:      "0.0.0.0/0"
-      ingress.{ident2}.from_port:          "443"
+      ingress.{ident2}.from_port:          "80"
       ingress.{ident2}.ipv6_cidr_blocks.#: "0"
       ingress.{ident2}.protocol:           "tcp"
       ingress.{ident2}.security_groups.#:  "0"
       ingress.{ident2}.self:               "false"
-      ingress.{ident2}.to_port:            "443"
+      ingress.{ident2}.to_port:            "80"
+      ingress.{ident3}.cidr_blocks.#:      "1"
+      ingress.{ident3}.cidr_blocks.0:      "0.0.0.0/0"
+      ingress.{ident3}.from_port:          "443"
+      ingress.{ident3}.ipv6_cidr_blocks.#: "0"
+      ingress.{ident3}.protocol:           "tcp"
+      ingress.{ident3}.security_groups.#:  "0"
+      ingress.{ident3}.self:               "false"
+      ingress.{ident3}.to_port:            "443"
       name:                                  <computed>
       owner_id:                              <computed>
       vpc_id:                                "vpc-12345678"
-
         """.strip()), output) # noqa
 
+
     def test_create_fastly_config(self):
+
         # When
         output = check_output([
             'terraform',

--- a/variables.tf
+++ b/variables.tf
@@ -117,3 +117,15 @@ variable "health_check_matcher" {
   type        = "string"
   default     = "200-299"
 }
+
+variable "custom_vcl_backends" {
+  type        = "string"
+  description = "Custom VCL to add at the top level (e.g. for defining backends)"
+  default     = ""
+}
+
+variable "custom_vcl_recv" {
+  type        = "string"
+  description = "Custom VCL to add to the vcl_recv sub after the Fastly hook"
+  default     = ""
+}


### PR DESCRIPTION
So that users of tf_frontend_router can set custom vcl - e.g. to route
to a marketting site.