### PR TITLE
Pass through custom_vcl_error

### DIFF
--- a/fastly.tf
+++ b/fastly.tf
@@ -13,4 +13,5 @@ module "fastly" {
   between_bytes_timeout     = "${var.between_bytes_timeout}"
   custom_vcl_backends       = "${var.custom_vcl_backends}"
   custom_vcl_recv           = "${var.custom_vcl_recv}"
+  custom_vcl_error          = "${var.custom_vcl_error}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -129,3 +129,9 @@ variable "custom_vcl_recv" {
   description = "Custom VCL to add to the vcl_recv sub after the Fastly hook"
   default     = ""
 }
+
+variable "custom_vcl_error" {
+  type        = "string"
+  description = "Custom VCL to add to the vcl_error sub after the Fastly hook"
+  default     = ""
+}


### PR DESCRIPTION
Allow frontends to customise the fastly behaviour when vcl_recv errors -
e.g. when the cache and backend is bypassed in order to serve a
synthentic response (e.g. issue a redirect).

JIRA: PLAT-345