### PR TITLE
Parameterise cluster for security group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ module "alb" {
   name                     = "${replace(replace(format("%s-%s", var.env, var.component), "/(.{0,25}).*/", "$1"), "/^-+|-+$/", "")}-router"
   vpc_id                   = "${var.platform_config["vpc"]}"
   subnet_ids               = ["${split(",", var.platform_config["public_subnets"])}"]
-  extra_security_groups    = ["${var.platform_config["ecs_cluster.default.client_security_group"]}"]
+  extra_security_groups    = ["${var.platform_config["ecs_cluster.${var.ecs_cluster}.client_security_group"]}"]
   internal                 = "false"
   certificate_domain_name  = "${format("*.%s%s", var.env != "live" ? "dev." : "", var.alb_domain)}"
   default_target_group_arn = "${aws_alb_target_group.default_target_group.arn}"

--- a/test/test_tf_frontend_router.py
+++ b/test/test_tf_frontend_router.py
@@ -443,10 +443,10 @@ Plan: 6 to add, 0 to change, 0 to destroy.
 
         # Then
         assert re.search(template_to_re("""
-      condition.{ident}.name:                    "response-503-condition"
-      condition.{ident}.priority:                "5"
-      condition.{ident}.statement:               "beresp.status == 503"
-      condition.{ident}.type:                    "CACHE"
+      condition.{ident}.name:                     "response-503-condition"
+      condition.{ident}.priority:                 "5"
+      condition.{ident}.statement:                "beresp.status == 503 && req.http.Cookie:viewerror != \\"true\\""
+      condition.{ident}.type:                     "CACHE"
         """.strip()), output) # noqa
 
     def test_create_fastly_config_response_503_definition(self):
@@ -622,7 +622,7 @@ Plan: 6 to add, 0 to change, 0 to destroy.
         assert re.search(template_to_re("""
       condition.{ident}.name:                    "response-502-condition"
       condition.{ident}.priority:                "5"
-      condition.{ident}.statement:               "beresp.status == 502"
+      condition.{ident}.statement:               "beresp.status == 502 && req.http.Cookie:viewerror != \\"true\\""
       condition.{ident}.type:                    "CACHE"
         """.strip()), output) # noqa
 

--- a/variables.tf
+++ b/variables.tf
@@ -179,3 +179,9 @@ variable "proxy_error_response" {
 </html>
 EOF
 }
+
+variable "ecs_cluster" {
+  type        = "string"
+  description = "The ecs cluster where the services will run (for the security group)."
+  default     = "default"
+}


### PR DESCRIPTION
This allows services running in clusters other than default, like
confluence and jira. This also fixes the tests, which were broken by
changes to a module it uses.